### PR TITLE
fix: Add allowed domain for OpenCage Data API in SecurityUtils

### DIFF
--- a/public/game/ressources/scripts/SecurityUtils.js
+++ b/public/game/ressources/scripts/SecurityUtils.js
@@ -198,7 +198,8 @@ class SecurityUtils {
         // Define allowed domains for content loading
         const allowedDomains = [
             window.location.origin,
-            'https://cdnjs.cloudflare.com'
+            'https://cdnjs.cloudflare.com',
+            'https://api.opencagedata.com'
         ];
 
         try {


### PR DESCRIPTION
I added the API webside to the validateContentSource in SecurityUtils.js